### PR TITLE
Refactor script and add basic test

### DIFF
--- a/Short Distance Travel.py
+++ b/Short Distance Travel.py
@@ -26,107 +26,97 @@ capitals_data = [
     ('Jakarta', -6.2088, 106.8456, 'IDN', 'Indonesia')
 ]
 
-# Initialize the Folium map centered around Hong Kong
-m = folium.Map(location=[22.3193, 114.1694], zoom_start=5)
-
-# Loop through capitals data and add markers
-for name, lat, lon, code, country_name in capitals_data:
-    folium.Marker(
-        location=[lat, lon],
-        tooltip=name,
-        icon=folium.Icon(color='lightgray', icon='info-sign')
-    ).add_to(m)
-
-# Style function for GeoJSON layers
 def style_function(feature):
     return {'fillColor': 'blue', 'color': 'black', 'weight': 1, 'fillOpacity': 0.6}
 
-# Base URL for the GeoJSON files of other countries
 base_url = 'https://raw.githubusercontent.com/johan/world.geo.json/master/countries/{}.geo.json'
 
-# Special handling for Singapore and Palau within the loop
-for name, lat, lon, code, country_name in capitals_data:
-    try:
-        if code == 'SGP':
-            singapore_geojson_url = 'https://raw.githubusercontent.com/yinshanyang/singapore/master/maps/0-country.geojson'
-            folium.GeoJson(singapore_geojson_url, name='Singapore', style_function=style_function).add_to(m)
-        elif code == 'PLW':
-            # Custom rectangle for Palau as previously defined
-            # Insert the custom GeoJSON for Palau here
-            palau_geojson_data = {
-                "type": "FeatureCollection",
-                "features": [{
-                    "type": "Feature",
-                    "properties": {"name": "Palau"},
-                    "geometry": {
-                      "type": "Polygon",
-                     "coordinates": [[
-                            [134.00012, 6.800],  # Bottom-left
-                            [134.56012, 7.000],   # Top-left
-                            [134.7434, 7.872],    # Top-right
-                            [134.5434, 7.806],   # Bottom-right
-                            [134.46012, 7.5006]   # Back to Bottom-left to close the polygon
-                        ]]
-                    }
-                }]
-            }
-            folium.GeoJson(palau_geojson_data, name='Palau',style_function=style_function).add_to(m)
-        else:
-            # Use the base URL for other countries
-            geojson_url = base_url.format(code)
-            folium.GeoJson(geojson_url, name=country_name, style_function=style_function).add_to(m)
-    except Exception as e:
-        print(f"Failed to load {code}: {e}")
 
-# Draw a circle around Hong Kong with a radius of 3500 km
-folium.Circle(
-    location=[22.3193, 114.1694],
-    radius=3500000,
-    color='blue',
-    fill=True,
-    fill_color='blue',
-    fill_opacity=0.2,
-    weight=1
-).add_to(m)
+def generate_map(output_path: str) -> str:
+    """Generate the travel map and save it to *output_path*."""
+    m = folium.Map(location=[22.3193, 114.1694], zoom_start=5)
 
-# Correctly add a layer control to toggle countries
-folium.LayerControl().add_to(m)
+    for name, lat, lon, code, country_name in capitals_data:
+        folium.Marker(
+            location=[lat, lon],
+            tooltip=name,
+            icon=folium.Icon(color='lightgray', icon='info-sign')
+        ).add_to(m)
 
-# Define Hong Kong's location
-hk_location = [22.3193, 114.1694]
+    for name, lat, lon, code, country_name in capitals_data:
+        try:
+            if code == 'SGP':
+                sg_url = 'https://raw.githubusercontent.com/yinshanyang/singapore/master/maps/0-country.geojson'
+                folium.GeoJson(sg_url, name='Singapore', style_function=style_function).add_to(m)
+            elif code == 'PLW':
+                # Custom polygon for Palau
+                palau_geojson_data = {
+                    "type": "FeatureCollection",
+                    "features": [{
+                        "type": "Feature",
+                        "properties": {"name": "Palau"},
+                        "geometry": {
+                            "type": "Polygon",
+                            "coordinates": [[
+                                [134.00012, 6.800],  # Bottom-left
+                                [134.56012, 7.000],   # Top-left
+                                [134.7434, 7.872],    # Top-right
+                                [134.5434, 7.806],    # Bottom-right
+                                [134.00012, 6.800]    # Back to Bottom-left to close the polygon
+                            ]]
+                        }
+                    }]
+                }
+                folium.GeoJson(palau_geojson_data, name='Palau', style_function=style_function).add_to(m)
+            else:
+                geojson_url = base_url.format(code)
+                folium.GeoJson(geojson_url, name=country_name, style_function=style_function).add_to(m)
+        except Exception as e:
+            print(f"Failed to load {code}: {e}")
 
-# Calculate an endpoint for the line, simplistically moving eastward
-# This is a simplified calculation and may not accurately represent 3,500 km on the map's projection
-radius_km = 3500
-# Approximate conversion assuming uniform degree distance at this latitude
-km_per_degree = 102.66
-change_in_longitude = radius_km / km_per_degree
-end_location = [hk_location[0], hk_location[1] + change_in_longitude]
+    folium.Circle(
+        location=[22.3193, 114.1694],
+        radius=3500000,
+        color='blue',
+        fill=True,
+        fill_color='blue',
+        fill_opacity=0.2,
+        weight=1
+    ).add_to(m)
 
-# Add a dashed line for the radius
-folium.PolyLine(
-    locations=[hk_location, end_location],
-    color='blue',
-    weight=2,
-    dash_array='5, 5',  # Creates a dashed line pattern
-).add_to(m)
+    folium.LayerControl().add_to(m)
 
-# Adding a label for the radius line
-# Note: Folium doesn't support direct text labels on lines. As a workaround, you can use a Popup on a hidden marker.
-radius_label_location = [((hk_location[0] + end_location[0]) / 2)+1, (hk_location[1] + end_location[1]) / 2]  # Midpoint
+    hk_location = [22.3193, 114.1694]
 
-radius_marker = folium.Marker(
-    location=radius_label_location,
-    icon=folium.DivIcon(html='''
-        <div style="font-size: 10pt; color: blue; width: 100px; white-space: nowrap;">5 hours flight</div>
-    '''),
-    popup='3,500 km'
-)
+    radius_km = 3500
+    km_per_degree = 102.66
+    change_in_longitude = radius_km / km_per_degree
+    end_location = [hk_location[0], hk_location[1] + change_in_longitude]
 
-radius_marker.add_to(m)
+    folium.PolyLine(
+        locations=[hk_location, end_location],
+        color='blue',
+        weight=2,
+        dash_array='5, 5'
+    ).add_to(m)
 
-# Dynamically get the directory of the current script to save the map
-script_dir = os.path.dirname(os.path.abspath(__file__))
-map_file_path = os.path.join(script_dir, 'Travel Map.html')
+    radius_label_location = [((hk_location[0] + end_location[0]) / 2)+1, (hk_location[1] + end_location[1]) / 2]
 
-m.save(map_file_path)
+    radius_marker = folium.Marker(
+        location=radius_label_location,
+        icon=folium.DivIcon(html='''
+            <div style="font-size: 10pt; color: blue; width: 100px; white-space: nowrap;">5-hour flight</div>
+        '''),
+        popup='3,500 km'
+    )
+
+    radius_marker.add_to(m)
+
+    m.save(output_path)
+    return output_path
+
+
+if __name__ == "__main__":
+    script_dir = os.path.dirname(os.path.abspath(__file__))
+    map_file_path = os.path.join(script_dir, 'Travel Map.html')
+    generate_map(map_file_path)

--- a/tests/test_map.py
+++ b/tests/test_map.py
@@ -1,0 +1,14 @@
+import importlib.util
+from pathlib import Path
+
+# Load the module with spaces in the filename
+module_path = Path(__file__).resolve().parents[1] / 'Short Distance Travel.py'
+spec = importlib.util.spec_from_file_location('sdt', module_path)
+sdt = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(sdt)
+
+def test_generate_map(tmp_path):
+    output = tmp_path / 'Travel Map.html'
+    sdt.generate_map(str(output))
+    assert output.exists()
+    assert output.stat().st_size > 0


### PR DESCRIPTION
## Summary
- wrap map generation logic in `generate_map`
- close Palau polygon properly and update comment
- fix flight duration label typo
- add pytest-based smoke test for map generation

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'folium')*

------
https://chatgpt.com/codex/tasks/task_e_6844509628dc832080870ae1677c9330